### PR TITLE
Fixed wrong Application file reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<start-class>khs.trouble.boot.Application</start-class>
+		<start-class>khs.trouble.Application</start-class>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Running the application with `java -jar` doesn't work with the old start-class configuration.